### PR TITLE
Don't use single-param setq

### DIFF
--- a/eno.el
+++ b/eno.el
@@ -183,7 +183,7 @@
 (defun eno-make-overlay-regexp (re beg end)
   (save-excursion
     (goto-char beg)
-    (setq ovs)
+    (setq ovs nil)
     (while (re-search-forward re end t)
       (unless (get-char-property (point) 'invisible)
         (push (make-overlay (match-beginning 0)


### PR DESCRIPTION
emacs-25 (development) doesn't like (setq ovs), which
breaks eno:
   save-excursion: Wrong number of arguments: setq, 1

So, use
   (setq ovs nil)
instead
